### PR TITLE
Adds a few missing specs

### DIFF
--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -6,22 +6,43 @@ module TFA
       ::ROTP::TOTP.new(secret).now
     end
 
-    let(:secret) { ::ROTP::Base32.random_base32 }
+    let(:dev_secret) { ::ROTP::Base32.random_base32 }
+    let(:prod_secret) { ::ROTP::Base32.random_base32 }
 
     describe "#add" do
       context "when a secret is added" do
         it "adds the secret" do
-          subject.add("development", secret)
-          expect(subject.show("development")).to eql(secret)
+          subject.add("development", dev_secret)
+          expect(subject.show("development")).to eql(dev_secret)
         end
       end
 
       context "when a full otpauth string is added" do
         it "strips out the url for just the secret" do
-          url = "otpauth://totp/email@email.com?secret=#{secret}&issuer="
+          url = "otpauth://totp/email@email.com?secret=#{dev_secret}&issuer="
 
           subject.add("development", url)
-          expect(subject.show("development")).to eql(secret)
+          expect(subject.show("development")).to eql(dev_secret)
+        end
+      end
+    end
+
+    describe "#show" do
+      context "when a single key is given" do
+        it "returns the secret" do
+          subject.add("development", dev_secret)
+          expect(subject.show("development")).to eql(dev_secret)
+        end
+      end
+
+      context "when no key is given" do
+        it "returns the secret for all keys" do
+          subject.add("development", dev_secret)
+          subject.add("production", prod_secret)
+
+          result = subject.show.to_s
+          expect(result).to include(dev_secret)
+          expect(result).to include(prod_secret)
         end
       end
     end
@@ -29,22 +50,19 @@ module TFA
     describe "#totp" do
       context "when a single key is given" do
         it "returns a time based one time password" do
-          subject.add("development", secret)
-          expect(subject.totp("development")).to eql(code_for(secret))
+          subject.add("development", dev_secret)
+          expect(subject.totp("development")).to eql(code_for(dev_secret))
         end
       end
 
       context "when no key is given" do
         it "returns a time based one time password for all keys" do
-          secret1 = secret
-          secret2 = ::ROTP::Base32.random_base32
-
-          subject.add("development", secret1)
-          subject.add("production", secret2)
+          subject.add("development", dev_secret)
+          subject.add("production", prod_secret)
 
           result = subject.totp.to_s
-          expect(result).to include(code_for(secret1))
-          expect(result).to include(code_for(secret2))
+          expect(result).to include(code_for(dev_secret))
+          expect(result).to include(code_for(prod_secret))
         end
       end
     end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -33,6 +33,20 @@ module TFA
           expect(subject.totp("development")).to eql(code_for(secret))
         end
       end
+
+      context "when no key is given" do
+        it "returns a time based one time password for all keys" do
+          secret1 = secret
+          secret2 = ::ROTP::Base32.random_base32
+
+          subject.add("development", secret1)
+          subject.add("production", secret2)
+
+          result = subject.totp.to_s
+          expect(result).to include(code_for(secret1))
+          expect(result).to include(code_for(secret2))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Not sure if it's intended behavior, but using the `totp` or `show` without a key dumps all values out, which is really nice. Wrote specs to encompass that as a "feature"
