### PR TITLE
Bump thor version

### DIFF
--- a/lib/tfa/version.rb
+++ b/lib/tfa/version.rb
@@ -1,3 +1,3 @@
 module TFA
-  VERSION = "0.0.16".freeze
+  VERSION = "0.0.17".freeze
 end

--- a/tfa.gemspec
+++ b/tfa.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rotp", "~> 3.3"
   spec.add_dependency "rqrcode", "~> 0.10"
-  spec.add_dependency "thor", "~> 0.20"
+  spec.add_dependency "thor", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"


### PR DESCRIPTION
# Why is this needed?
Required Thor versions allowed in gemspec is set up use Thor versions "thor", "~> 0.20" which limits allowed versions to those 0.x.x.  We need to be able to access versions 1.x.x.

## What does this do?
Allows TFA to be used in combination with other gems without encountering conflicts in versions of thor >1.x.x

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification Plan
- [x] Step 1 Add to application and verify bundle does not encounter conflicts
- [x] Step 2 Use in application to verify functionality has not been adversely affected.
- [x] Step 3 Use CLI interface and verify functionality has not been adversely affected.
